### PR TITLE
Modify types for ForwardDiff.jl compatibility

### DIFF
--- a/src/cell_list.jl
+++ b/src/cell_list.jl
@@ -99,8 +99,8 @@ end
 # ==================== CellList Core  ================
 
 
-function _celllist_(X::Vector{SVec{T}}, cell::SMat{T}, pbc::SVec{Bool},
-            cutoff::T, TI) where {T <: AbstractFloat}
+function _celllist_(X::Vector{<:SVec}, cell::SMat, pbc::SVec{Bool},
+            cutoff::T, TI) where {T <: Real}
    @assert TI <: Integer
    # ----- analyze cell -----
    nat = length(X)

--- a/src/types.jl
+++ b/src/types.jl
@@ -37,7 +37,7 @@ it is different. `first[m]` contains the index to the first `(i[n], j[n])` for
 which `i[n] == first[m]`, i.e., `(j, first)` essentially defines a compressed
 column storage of the adjacancy matrix.
 """
-struct PairList{T <: AbstractFloat, TI <: Integer}
+struct PairList{T <: Real, TI <: Integer}
    X::Vector{SVec{T}}
    C::SMat{T}
    cutoff::T
@@ -52,7 +52,7 @@ end
 `CellList` : store atoms in cells / bins. Mostly used internally
 to construct PairLists.
 """
-struct CellList{T <: AbstractFloat, TI <: Integer}
+struct CellList{T <: Real, TI <: Integer}
    X::Vector{SVec{T}}
    cell::SMat{T}
    inv_cell::SMat{T}


### PR DESCRIPTION
I was attempting to use NeighbourLists.jl with ForwardDiff.jl but ran into issues with the ForwardDiff dual types. With these changes it works without issue.