### PR TITLE
support AtomsBase v0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 julia = "1"
 StaticArrays = "1"
-AtomsBase = "0.3"
+AtomsBase = "0.3, 0.4"
 Unitful = "1"
 
 [extras]


### PR DESCRIPTION
As title says.

This only updates version bounds nothing else is needed.

@cortner once CI passes this is ready to merge, and you can tag a new version of NeighboutLists.