### PR TITLE
AtomsBase v0.5 update

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8'
           - '1.9'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 julia = "1"
 StaticArrays = "1"
-AtomsBase = "0.3, 0.4"
+AtomsBase = "0.5"
 LinearAlgebra = "1"
 Unitful = "1"
 

--- a/src/atoms_base.jl
+++ b/src/atoms_base.jl
@@ -4,7 +4,7 @@ using Unitful
 
 
 function PairList(ab::AtomsBase.AbstractSystem, cutoff::Unitful.Length; length_unit=unit(cutoff))
-    cell = ustrip.(length_unit, hcat( bounding_box(ab)... )' )
+    cell = ustrip.(length_unit, hcat( cell_vectors(ab)... )' )
     pbc = periodicity(ab)
     r = map( 1:length(ab) ) do i
         # Need to have SVector here for PairList to work

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,5 @@
 [deps]
-ASEconvert = "3da9722f-58c2-4165-81be-b4d7253e8fd2"
+AtomsBuilder = "f5cc8831-eeb7-4288-8d9f-d6c1ddb77004"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/test_atoms_base.jl
+++ b/test/test_atoms_base.jl
@@ -1,11 +1,11 @@
-using ASEconvert
+#using ASEconvert
+using AtomsBuilder
 using NeighbourLists
 using Test
 using Unitful
 
 @testset "AtomsBase PairList" begin
-    cu = ase.build.bulk("Cu") * pytuple((4, 2, 3))
-    sys = pyconvert(AbstractSystem, cu)
+    sys = bulk(:Cu, cubic=true) * (4,2,3)
 
     nlist = PairList(sys, 3.5u"Å")
 


### PR DESCRIPTION
Update to AB v0.5 that is needed for AtomsCalculatorsUtilities.jl and EmpiricalPotentials.jl https://github.com/JuliaMolSim/EmpiricalPotentials.jl/pull/30.

There is also an update to testing part to swap to use AtomsBuilder.jl instead of using ASEconvert.jl. 